### PR TITLE
Configure pre-commit with black, isort, and ruff for automatic code formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.3.0
+    hooks:
+      - id: black
+        language_version: python3
+        args: ["--quiet"]  # Suppress extra output
+
+  - repo: https://github.com/pre-commit/mirrors-isort
+    rev: v5.10.1
+    hooks:
+      - id: isort
+        language_version: python3
+        args: ["--profile", "black"]  # Matches Black style
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.4
+    hooks:
+      - id: ruff
+        language_version: python3

--- a/cogs/proposals.py
+++ b/cogs/proposals.py
@@ -1,13 +1,14 @@
-import tomllib
-import logging
-import discord
 import json
+import logging
 import os
+from datetime import datetime, timezone
 
+import discord
+import tomllib
 from discord.ext import commands, tasks
+
 from core import QadirBot
 from modals import CreateProposalModal
-from datetime import datetime, timezone
 
 if os.getenv("PYTHON_ENV") == "production":
     with open("config.toml", "rb") as f:

--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -1,6 +1,6 @@
 import discord
-
 from discord.ext import commands
+
 from core import QadirBot
 
 
@@ -23,7 +23,7 @@ class UtilityCog(commands.Cog):
         dev_id = 244662779745665026
 
         embed = discord.Embed(title="App Information", description=f"A magical application created by <@{dev_id}>.", colour=0x00FF00)
-        embed.add_field(name="Version", value=f"`{self.bot.config["app"]["version"]}`")
+        embed.add_field(name="Version", value=f"`{self.bot.config['app']['version']}`")
         embed.add_field(name="Latency", value=f"`{round(self.bot.latency * 100)} ms`")
         embed.add_field(name="Guilds", value=f"`{len(self.bot.guilds)}`", inline=False)
 

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,3 +1,3 @@
 from .bot import QadirBot
 
-__all__ = "QadirBot"
+__all__ = ["QadirBot"]

--- a/core/bot.py
+++ b/core/bot.py
@@ -1,6 +1,6 @@
 import logging
 
-from discord import Bot, ApplicationContext
+from discord import ApplicationContext, Bot
 from upstash_redis.asyncio import Redis
 
 logger = logging.getLogger("qadir")

--- a/main.py
+++ b/main.py
@@ -1,12 +1,12 @@
-from dotenv import load_dotenv
-
-import sys
-import tomllib
 import logging
 import os
+import sys
+
+import tomllib
 
 # Discord
 from discord import Intents
+from dotenv import load_dotenv
 
 # Core
 from core import QadirBot

--- a/modals/create_proposal.py
+++ b/modals/create_proposal.py
@@ -1,9 +1,10 @@
-import tomllib
-import logging
-import discord
 import json
+import logging
 import os
 import re
+
+import discord
+import tomllib
 
 from core import QadirBot
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     {name = "Bilal",email = "mail@bil.al"}
 ]
 readme = "README.md"
-requires-python = "3.12.3"
+requires-python = ">=3.12"
 dependencies = [
     "py-cord[speed] (>=2.6.1,<3.0.0)",
     "python-dotenv (>=1.1.0,<2.0.0)",


### PR DESCRIPTION
📝 Commit Summary:
Added .pre-commit-config.yaml to enforce consistent code style.

Installed hooks for:

black → formats Python code

isort → organizes imports

ruff → lints and auto-fixes common issues

Ran pre-commit run --all-files to format existing code.

Fixed minor syntax and import issues flagged during initial run.

Now all future commits will be automatically formatted and linted before they’re accepted.